### PR TITLE
removed head from swin4d_transformer_ver7.py

### DIFF
--- a/project/module/models/swin4d_transformer_ver7.py
+++ b/project/module/models/swin4d_transformer_ver7.py
@@ -797,7 +797,7 @@ class SwinTransformer4D(nn.Module):
 
         self.norm = norm_layer(self.num_features)
         self.avgpool = nn.AdaptiveAvgPool1d(1)  #
-        self.head = nn.Linear(self.num_features, 1) if num_classes == 2 else num_classes
+        # self.head = nn.Linear(self.num_features, 1) if num_classes == 2 else num_classes # moved this part to clf_mlp or reg_mlp
 
 
     def forward(self, x):


### PR DESCRIPTION
The head causes problems when loading/saving state_dics, needs to be removed. Has already been moved to clf_mlp/reg_mlp in the forward function.